### PR TITLE
Fix crashing actually

### DIFF
--- a/RaidBuffTracker/RaidBuffTracker.csproj
+++ b/RaidBuffTracker/RaidBuffTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>shdwp, Iaotle</Authors>
     <Company></Company>
-    <Version>1.0.2.0</Version>
+    <Version>1.0.2.1</Version>
     <Description>Tracks Raid Buffs for you in a convenient widget.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/shdwp/xivRaidBuffTracker</PackageProjectUrl>

--- a/RaidBuffTracker/Tracker/Library/ActionLibraryRecord.cs
+++ b/RaidBuffTracker/Tracker/Library/ActionLibraryRecord.cs
@@ -27,9 +27,8 @@ namespace RaidBuffTracker.Tracker.Library
         public bool IsApplicableToSource(ActionTrackSource? source)
         {
             if (source == null) return false;
-            var notnull_source = (ActionTrackSource) source;
             //PluginLog.Warning("job affin {x}, minlvl {y}, source.lvl {z}", jobAffinity, minLvl, source.lvl);
-            return jobAffinity.Contains(notnull_source.jobAbbr) && notnull_source.lvl >= minLvl;
+            return jobAffinity.Contains(source.Value.jobAbbr) && source.Value.lvl >= minLvl;
             // return source.lvl >= minLvl && jobAffinity.Contains(source.jobAbbr);
         }
     }

--- a/RaidBuffTracker/Utils/PartyListHUD.cs
+++ b/RaidBuffTracker/Utils/PartyListHUD.cs
@@ -21,7 +21,7 @@ namespace RaidBuffTracker.Utils
             var result = new List<uint>();
             for (var i = 0; i < hud->PartyMemberCount; i++)
             {
-                result.Add(list[i].ObjectId);
+                //result.Add(list[i].ObjectId);
             }
 
             return result;


### PR DESCRIPTION
apparently `result.Add(list[i].ObjectId)` is the thing that causes crashing due to accessing protected memory. hmm

if you want me to maintain the project btw maybe just give me write access so I can push myself?